### PR TITLE
Dockerfile: Use prebuilt clang-10 binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,21 +12,15 @@ RUN apt update \
   ninja-build \
   python3 \
   vim \
+  curl \
  && apt autoremove
 
 WORKDIR /root
-RUN git clone --depth=1 --branch llvmorg-10.0.0 https://github.com/llvm/llvm-project.git
-RUN mkdir build \
- && cd build \
- && cmake -G Ninja -DCMAKE_BUILD_TYPE=Release \
-  -DLLVM_ENABLE_PROJECTS="clang;lld" \
-  -DLLVM_TARGETS_TO_BUILD="AArch64;ARM" \
-  /root/llvm-project/llvm \
- && ninja \
- && DESTDIR=/tmp/clang-install ninja install
+RUN curl -s -L https://fileserver.linaro.org/s/da26ygYptknxwSk/download -o clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04
+RUN tar xf clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04
 
 FROM jforissier/optee_os_ci
 MAINTAINER Jerome Forissier <jerome@forissier.org>
 
-COPY --from=clang-builder /tmp/clang-install/usr/local/ /usr/local/
+COPY --from=clang-builder /root/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04/ /usr/local/
 


### PR DESCRIPTION
Download a customized copy of prebuilt clang-10 binary instead of
building our own.

This copy is basically [1] with libclang_rt.builtins-aarch64.a from [2]
and libclang_rt.builtins-armhf.a from [3] added since these runtime
libraries are required for linking during an optee_os build.

LINK: [1] https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
LINK: [2] https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-aarch64-linux-gnu.tar.xz
LINK: [3] https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-armv7a-linux-gnueabihf.tar.xz

Signed-off-by: Victor Chong <victor.chong@linaro.org>