### PR TITLE
Download pre-built Clang 10.0.0 from GitHub

### DIFF
--- a/get_clang.sh
+++ b/get_clang.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Download and extract Clang from the GitHub release page.
+# We want a x86_64 cross-compiler capable of generating aarch64 and armv7a code
+# *and* we want the compiler-rt libraries for these architectures
+# (libclang_rt.*.a).
+# Clang is configured to be able to cross-compile to all the supported
+# architectures by default (see <clang path>/bin/llc --version) which is great,
+# but compiler-rt is included only for the host architecture. Therefore we need
+# to combine several packages into one, which is the purpose of this script.
+#
+# Usage: get_clang.sh [path]
+
+DEST=${1:-./clang}
+
+VER=10.0.0
+X86_64=clang+llvm-${VER}-x86_64-linux-gnu-ubuntu-18.04
+AARCH64=clang+llvm-${VER}-aarch64-linux-gnu
+ARMV7A=clang+llvm-${VER}-armv7a-linux-gnueabihf
+
+(wget -nv https://github.com/llvm/llvm-project/releases/download/llvmorg-${VER}/${X86_64}.tar.xz && tar xf ${X86_64}.tar.xz) &
+pids=$!
+(wget -nv https://github.com/llvm/llvm-project/releases/download/llvmorg-${VER}/${AARCH64}.tar.xz && tar xf ${AARCH64}.tar.xz) &
+pids="$pids $!"
+(wget -nv https://github.com/llvm/llvm-project/releases/download/llvmorg-${VER}/${ARMV7A}.tar.xz && tar xf ${ARMV7A}.tar.xz) &
+pids="$pids $!"
+wait $pids || exit 1
+
+mv ${X86_64} ${DEST} || exit 1
+cp ${AARCH64}/lib/clang/${VER}/lib/linux/* ${DEST}/lib/clang/${VER}/lib/linux || exit 1
+cp ${ARMV7A}/lib/clang/${VER}/lib/linux/* ${DEST}/lib/clang/${VER}/lib/linux || exit 1


### PR DESCRIPTION
Do not re-build Clang 10, because:

1. It is now available pre-built on the GitHub release page of the LLVM
   project,
2. Our local build doesn't produce the compiler-rt libraries for the
   aarch64 and armv7a targets. Building them is not obvious, so instead
   we download and combine several compiler packages via a script.
   The compiler-rt libraries are replacement for libgcc.a; there are
   expected to be required soon by optee_os [1].

[1] https://github.com/OP-TEE/optee_os/pull/3844

Suggested-by: Victor Chong <victor.chong@linaro.org>
Signed-off-by: Jerome Forissier <jerome@forissier.org>